### PR TITLE
KinD in codespaces workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 This is the companion repo for Module 6 of the O'Reilly Observability Fundamentals video course.
 
-> 🚨🚨 **NOTE:** There is currently a bug that is preventing KinD from running in GitHub codespaces. To work around this, you can run this tutorial locally in VSCode using [dev containers](https://code.visualstudio.com/docs/devcontainers/tutorial). I have opened this issue with the KinD folks in the hopes of getting some sort of resolution: https://github.com/kubernetes-sigs/kind/issues/3748.
-
-
 ## References
 
 Course references can be found [here](./docs/references.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-> 🚨🚨 **NOTE:** There is currently a bug that is preventing KinD from running in GitHub codespaces. To work around this, you can run this tutorial locally in VSCode using [dev containers](https://code.visualstudio.com/docs/devcontainers/tutorial). I have opened this issue with the KinD folks in the hopes of getting some sort of resolution: https://github.com/kubernetes-sigs/kind/issues/3748.
+> 🚨🚨 **NOTE:** There is currently a bug that is preventing KinD from running in GitHub codespaces. The workaround has been to manually create the docker network and exclude the `--ipv6` flag before creating a the KinD cluster. This is already accounted for run you run the [setup script](../src/scripts/setup.sh), so no further action is required! You can track the issue [here](https://github.com/kubernetes-sigs/kind/issues/3748).
 
 ## Pre-requisites
 

--- a/src/scripts/setup-with-k9s.sh
+++ b/src/scripts/setup-with-k9s.sh
@@ -5,13 +5,23 @@
 # ---------------------------
 
 # Install KinD
-[ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64
+[ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
+[ $(uname -m) = aarch64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-arm64
+
 chmod +x ./kind
 sudo mv ./kind /usr/local/bin/kind
 kind --version
 
-# Create KinD cluster
+# Create KinD cluster. See the following GitHub issue for more on why I had to resort to manually creating the docker network: https://github.com/kubernetes-sigs/kind/issues/3748
+docker network create -d=bridge -o com.docker.network.bridge.enable_ip_masquerade=true -o com.docker.network.driver.mtu=1500 --subnet fc00:f853:ccd:e793::/64 kind
 kind create cluster --name otel-python-lab
+
+# Install kubectl
+[ $(uname -m) = x86_64 ] && curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+[ $(uname -m) = aarch64 ] && curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl"
+
+chmod +x ./kubectl
+sudo mv ./kubectl /usr/local/bin/kubectl
 
 # ---------------------------
 # -- Install VSCode extensions

--- a/src/scripts/setup.sh
+++ b/src/scripts/setup.sh
@@ -12,7 +12,8 @@ chmod +x ./kind
 sudo mv ./kind /usr/local/bin/kind
 kind --version
 
-# Create KinD cluster
+# Create KinD cluster. See GitHub issue for more on manual docker network creation
+docker network create -d=bridge -o com.docker.network.bridge.enable_ip_masquerade=true -o com.docker.network.driver.mtu=1500 --subnet fc00:f853:ccd:e793::/64 kind
 kind create cluster --name otel-python-lab
 
 # Install kubectl

--- a/src/scripts/setup.sh
+++ b/src/scripts/setup.sh
@@ -12,7 +12,7 @@ chmod +x ./kind
 sudo mv ./kind /usr/local/bin/kind
 kind --version
 
-# Create KinD cluster. See GitHub issue for more on manual docker network creation
+# Create KinD cluster. See the following GitHub issue for more on why I had to resort to manually creating the docker network: https://github.com/kubernetes-sigs/kind/issues/3748
 docker network create -d=bridge -o com.docker.network.bridge.enable_ip_masquerade=true -o com.docker.network.driver.mtu=1500 --subnet fc00:f853:ccd:e793::/64 kind
 kind create cluster --name otel-python-lab
 


### PR DESCRIPTION
Adding workaround to address an issue in creating a KinD cluster in GitHub Codespaces. See issue reference [here](https://github.com/kubernetes-sigs/kind/issues/3748).